### PR TITLE
fixed startup.asm to stop all cores except one

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ rpi3.cpu1 cluster 0 core 1 multi core
 ## Load and start program
 
 ```
-> halt; load_image kernel.img 0 bin; reg pc 0; resume
+> targets rpi3.cpu; halt; load_image kernel.img 0 bin; reg pc 0; resume
 halt; load_image kernel.img 0 bin; reg pc 0; resume
 target state: halted
 target halted in ARM64 state due to debug-request, current mode: EL3H
@@ -72,6 +72,7 @@ pc (/64): 0x0000000000000000
 ## OpenOCD commands
 
  - `reset init`: prepare CPU for debugging
+ - `targets`: list and select cores
  - `halt`: stop execution
  - `resume`: resume execution
  - `reg`: show registers
@@ -79,3 +80,4 @@ pc (/64): 0x0000000000000000
  - `step`: single-step
  - `bp ADDR SIZE [hw]`: set a breakpoint at ADDR (you must supply the opcode size)
  - `load_image FILENAME ADDR [TYPE]`: copy program to RAM at given address
+ - `poll`: show debugging state

--- a/main.c
+++ b/main.c
@@ -181,7 +181,7 @@ static void uart_init(void)
 int main()
 {
 	uart_init();
-	dbg_puts("Waiting for JTAG\r\n");
+	dbg_puts("\r\nWaiting for JTAG\r\n");
 	enable_jtag();
 	while (1)
 	{

--- a/startup.asm
+++ b/startup.asm
@@ -28,6 +28,10 @@
 
 .globl _start
 _start:
+	mrs x2, MPIDR_EL1
+	and x2, x2, #0xFF
+	cbnz x2, hang
+
 	ldr x5, =0x00100000
 	mov sp, x5
 	bl main

--- a/startup.asm
+++ b/startup.asm
@@ -28,12 +28,18 @@
 
 .globl _start
 _start:
+	// all four cores are executing from here
+
+	// first, we need to stop all cores except core0
 	mrs x2, MPIDR_EL1
 	and x2, x2, #0xFF
 	cbnz x2, hang
 
+	// then, core0 can move on to execute the main c function
 	ldr x5, =0x00100000
 	mov sp, x5
 	bl main
+
+	// an infinite loop
 hang:
 	b hang


### PR DESCRIPTION
Hi Daniel,

I couldn't get your code to run properly, probably the bootcode.bin provided by the Raspberry Pi foundation changed or something. It seems like that all four cores run and start executing the code, using the same stack pointer and everything. I had multiple times the same four letters in the output and then a lot of them were skipped.

Anyways after adding these lines, the output looks smooth at least. I'll move on with testing JTAG now.

Best,
  Andreas